### PR TITLE
fix specific region implementation

### DIFF
--- a/include/sicgl/types.h
+++ b/include/sicgl/types.h
@@ -13,6 +13,6 @@ typedef uint32_t uext_t;
 typedef struct _screen_t {
   uext_t u0;
   uext_t v0;
-  ext_t width;
-  ext_t height;
+  uext_t width;
+  uext_t height;
 } screen_t;

--- a/src/specific.c
+++ b/src/specific.c
@@ -50,34 +50,36 @@ void sicgl_specific_region(specific_interface_t* interface, screen_t* screen,
   size_t dv;
   size_t bpp = interface->bpp;
   uint8_t* p = interface->memory;
+  size_t offset; // pixels
   size_t scratch_length = interface->pixels_scratch;
   uint8_t* scratch = interface->scratch;
   uext_t width = screen->width;
 
   // compute values
   if (u0 < u1) {
+    offset = u0;
     du = u1 - u0 + 1;
-    p += u0;
   } else {
+    offset = u1;
     du = u0 - u1 + 1;
-    p += u1;
   }
   if (v0 < v1) {
+    offset += width * v0;
     dv = v1 - v0 + 1;
-    p += width * v0;
   } else {
+    offset += width * v1;
     dv = v0 - v1 + 1;
-    p += width * v1;
   }
 
   if (scratch_length == 0) {
     // use naive pixel-by-pixel implementation
     for (size_t idv = 0; idv < dv; idv++) {
       for (size_t idu = 0; idu < du; idu++) {
-        memcpy(p, color, bpp);
-        p += bpp;
+        memcpy(interface->memory + bpp * offset, color, bpp);
+        offset++; // advance one column
       }
-      p += bpp * (width - du);  // adv to next row and back to starting column
+      offset += width; // advance one row
+      offset -= du; // advance back to starting column
     }
   } else {
     // fill scratch buffer once then copy it repeatedly

--- a/src/specific.c
+++ b/src/specific.c
@@ -50,7 +50,7 @@ void sicgl_specific_region(specific_interface_t* interface, screen_t* screen,
   size_t dv;
   size_t bpp = interface->bpp;
   uint8_t* p = interface->memory;
-  size_t offset; // pixels
+  size_t offset;  // pixels
   size_t scratch_length = interface->pixels_scratch;
   uint8_t* scratch = interface->scratch;
   uext_t width = screen->width;
@@ -76,10 +76,10 @@ void sicgl_specific_region(specific_interface_t* interface, screen_t* screen,
     for (size_t idv = 0; idv < dv; idv++) {
       for (size_t idu = 0; idu < du; idu++) {
         memcpy(interface->memory + bpp * offset, color, bpp);
-        offset++; // advance one column
+        offset++;  // advance one column
       }
-      offset += width; // advance one row
-      offset -= du; // advance back to starting column
+      offset += width;  // advance one row
+      offset -= du;     // advance back to starting column
     }
   } else {
     // fill scratch buffer once then copy it repeatedly

--- a/test/bitmap_utils.h
+++ b/test/bitmap_utils.h
@@ -22,16 +22,22 @@ typedef struct {
   bitmap_pixel_t pixels[];
 } bitmap_t;
 
+static inline void bitmap_free(bitmap_t* bitmap) { free(bitmap); }
+
 static inline bitmap_t* bitmap_new(size_t width, size_t height) {
   size_t num_pix = width * height;
   bitmap_t* bm = malloc(sizeof(bitmap_t) + sizeof(bitmap_pixel_t) * num_pix);
+  if (bm == NULL) {
+    goto out;
+  }
+
   bm->num_pix = num_pix;
   bm->width = width;
   bm->height = height;
+
+out:
   return bm;
 }
-
-static inline void bitmap_free(bitmap_t* bitmap) { free(bitmap); }
 
 void bitmap_to_file(bitmap_t const* bitmap, char const* path);
 

--- a/test/test_regions/main.c
+++ b/test/test_regions/main.c
@@ -61,6 +61,17 @@ DECLARE_TEST_CASE(location_test_two_generic_naive, true, 3, 5, false,
 DECLARE_TEST_CASE(location_test_two_specific, false, 3, 5, false,
                   pixel_location_expected_two, (void*)&test_color, 1, 1, 1, 3);
 
+const uint8_t pixel_location_expected_three[20] = {
+    0, 0, 0, 0, 0, test_color, test_color, 0, 0, test_color, test_color, 0, 0, test_color, test_color, 0, 0, 0, 0, 0,
+};
+DECLARE_TEST_CASE(location_test_three_generic_full, true, 4, 5, true,
+                  pixel_location_expected_three, (void*)&test_color, 1, 1, 2, 3);
+DECLARE_TEST_CASE(location_test_three_generic_naive, true, 4, 5, false,
+                  pixel_location_expected_three, (void*)&test_color, 1, 1, 2, 3);
+DECLARE_TEST_CASE(location_test_three_specific, false, 4, 5, false,
+                  pixel_location_expected_three, (void*)&test_color, 1, 1, 2, 3);
+
+
 // assemble the tests
 const location_test_case_t* location_tests[] = {
     // first test
@@ -72,6 +83,11 @@ const location_test_case_t* location_tests[] = {
     &location_test_two_generic_full,
     &location_test_two_generic_naive,
     &location_test_two_specific,
+
+    // third test
+    &location_test_three_generic_full,
+    &location_test_three_generic_naive,
+    &location_test_three_specific,
 };
 
 void setUp(void) {
@@ -168,19 +184,13 @@ void test_region(void) {
   spec_screen.v0 = 0;
 
   // draw some lines
-  const uint32_t region = 1;
-  // const uint32_t region = 250;
-  for (uint32_t count = 0; count < region; count++) {
+  const uint32_t regions = 250;
+  for (uint32_t count = 0; count < regions; count++) {
     uext_t u0 = rand() % width;
     uext_t v0 = rand() % height;
     uext_t u1 = rand() % width;
     uext_t v1 = rand() % height;
     bitmap_pixel_t pixel = bmp_random_color();
-
-    u0 = 0;
-    v0 = 0;
-    u1 = 0;
-    v1 = 0;
 
     // draw the pixel using the interfaces
     sicgl_generic_region(&fast_intfc, (void*)&pixel, u0, v0, u1, v1);

--- a/test/test_regions/main.c
+++ b/test/test_regions/main.c
@@ -62,15 +62,19 @@ DECLARE_TEST_CASE(location_test_two_specific, false, 3, 5, false,
                   pixel_location_expected_two, (void*)&test_color, 1, 1, 1, 3);
 
 const uint8_t pixel_location_expected_three[20] = {
-    0, 0, 0, 0, 0, test_color, test_color, 0, 0, test_color, test_color, 0, 0, test_color, test_color, 0, 0, 0, 0, 0,
+    0,          0, 0,          0,          0, test_color, test_color,
+    0,          0, test_color, test_color, 0, 0,          test_color,
+    test_color, 0, 0,          0,          0, 0,
 };
 DECLARE_TEST_CASE(location_test_three_generic_full, true, 4, 5, true,
-                  pixel_location_expected_three, (void*)&test_color, 1, 1, 2, 3);
+                  pixel_location_expected_three, (void*)&test_color, 1, 1, 2,
+                  3);
 DECLARE_TEST_CASE(location_test_three_generic_naive, true, 4, 5, false,
-                  pixel_location_expected_three, (void*)&test_color, 1, 1, 2, 3);
+                  pixel_location_expected_three, (void*)&test_color, 1, 1, 2,
+                  3);
 DECLARE_TEST_CASE(location_test_three_specific, false, 4, 5, false,
-                  pixel_location_expected_three, (void*)&test_color, 1, 1, 2, 3);
-
+                  pixel_location_expected_three, (void*)&test_color, 1, 1, 2,
+                  3);
 
 // assemble the tests
 const location_test_case_t* location_tests[] = {


### PR DESCRIPTION
this PR fixes the implementation of ```region``` for specific type interfaces. not quite sure why the original didn't work, however...

also fixes a typo in the ```screen_t``` definition and adds early bail on bitmap creation.