### PR TITLE
use width of intersection in compositor functions

### DIFF
--- a/include/sicgl/compose.h
+++ b/include/sicgl/compose.h
@@ -3,7 +3,8 @@
 #include "sicgl/interface.h"
 #include "sicgl/screen.h"
 
-typedef void (*compositor_fn)(color_t* source, color_t* destination);
+typedef void (*compositor_fn)(
+    color_t* source, color_t* destination, size_t width);
 int sicgl_compose(
     interface_t* interface, screen_t* screen, color_t* sprite,
     compositor_fn compositor);

--- a/src/compose.c
+++ b/src/compose.c
@@ -83,7 +83,9 @@ int sicgl_compose(
   // the sprite buffer to the target buffer (using the full width of the
   // intersection)
   for (size_t idx = 0; idx < intersection.height; idx++) {
-    compositor(&sprite[sprite_offset], &interface->memory[interface_offset]);
+    compositor(
+        &sprite[sprite_offset], &interface->memory[interface_offset],
+        intersection.width);
 
     // add whole rows to sprite and interface offsets
     sprite_offset += screen->width;


### PR DESCRIPTION
this fixes a bug where only a portion of the overlapping area was actually composed