### PR TITLE
rename color sequence interpolation functions

### DIFF
--- a/include/sicgl/color_sequence.h
+++ b/include/sicgl/color_sequence.h
@@ -32,12 +32,12 @@ int color_sequence_get_color(
 
 // color sequence map functions
 // map a double to a color from a color sequence
-int color_sequence_get_color_continuous_linear(
+int color_sequence_interpolate_color_continuous_linear(
     color_sequence_t* sequence, double phase, color_t* color);
-int color_sequence_get_color_continuous_circular(
+int color_sequence_interpolate_color_continuous_circular(
     color_sequence_t* sequence, double phase, color_t* color);
 
-int color_sequence_get_color_discrete_linear(
+int color_sequence_interpolate_color_discrete_linear(
     color_sequence_t* sequence, double phase, color_t* color);
-int color_sequence_get_color_discrete_circular(
+int color_sequence_interpolate_color_discrete_circular(
     color_sequence_t* sequence, double phase, color_t* color);

--- a/src/color_sequence.c
+++ b/src/color_sequence.c
@@ -54,7 +54,7 @@ out:
   return ret;
 }
 
-int color_sequence_get_color_continuous_linear(
+int color_sequence_interpolate_color_continuous_linear(
     color_sequence_t* sequence, double phase, color_t* color) {
   int ret = 0;
   if (NULL == sequence) {
@@ -75,7 +75,7 @@ int color_sequence_get_color_continuous_linear(
 out:
   return ret;
 }
-int color_sequence_get_color_continuous_circular(
+int color_sequence_interpolate_color_continuous_circular(
     color_sequence_t* sequence, double phase, color_t* color) {
   int ret = 0;
   if (NULL == sequence) {
@@ -97,7 +97,7 @@ out:
   return ret;
 }
 
-int color_sequence_get_color_discrete_linear(
+int color_sequence_interpolate_color_discrete_linear(
     color_sequence_t* sequence, double phase, color_t* color) {
   int ret = 0;
   if (NULL == sequence) {
@@ -136,7 +136,7 @@ out:
   return ret;
 }
 
-int color_sequence_get_color_discrete_circular(
+int color_sequence_interpolate_color_discrete_circular(
     color_sequence_t* sequence, double phase, color_t* color) {
   int ret = 0;
   if (NULL == sequence) {

--- a/test/tests/color_sequences/src/circular.c
+++ b/test/tests/color_sequences/src/circular.c
@@ -43,7 +43,7 @@ void test_circular_case1(void) {
       double phase = ((idu - 1) / (double)(width - 3));
 
       // perform the interpolation
-      ret = color_sequence_get_color_continuous_circular(
+      ret = color_sequence_interpolate_color_continuous_circular(
           color_sequence, phase, &color);
       TEST_ASSERT_EQUAL_INT(0, ret);
 
@@ -124,7 +124,7 @@ void test_circular_case2(void) {
       double phase = ((idu - 1) / (double)(width - 3));
 
       // perform the interpolation
-      ret = color_sequence_get_color_continuous_circular(
+      ret = color_sequence_interpolate_color_continuous_circular(
           color_sequence, phase, &color);
       TEST_ASSERT_EQUAL_INT(0, ret);
 
@@ -205,7 +205,7 @@ void test_circular_case3(void) {
       double phase = 2 * ((idu - 1) / (double)(width - 3));
 
       // perform the interpolation
-      ret = color_sequence_get_color_continuous_circular(
+      ret = color_sequence_interpolate_color_continuous_circular(
           color_sequence, phase, &color);
       TEST_ASSERT_EQUAL_INT(0, ret);
 
@@ -286,7 +286,7 @@ void test_circular_case4(void) {
       double phase = ((idu - 1) / (double)(width - 3));
 
       // perform the interpolation
-      ret = color_sequence_get_color_discrete_circular(
+      ret = color_sequence_interpolate_color_discrete_circular(
           color_sequence, phase, &color);
       TEST_ASSERT_EQUAL_INT(0, ret);
 

--- a/test/tests/color_sequences/src/linear.c
+++ b/test/tests/color_sequences/src/linear.c
@@ -43,7 +43,7 @@ void test_linear_case1(void) {
       double phase = ((idu - 1) / (double)(width - 3));
 
       // perform the interpolation
-      ret = color_sequence_get_color_continuous_linear(
+      ret = color_sequence_interpolate_color_continuous_linear(
           color_sequence, phase, &color);
       TEST_ASSERT_EQUAL_INT(0, ret);
 
@@ -124,7 +124,7 @@ void test_linear_case2(void) {
       double phase = ((idu - 1) / (double)(width - 3));
 
       // perform the interpolation
-      ret = color_sequence_get_color_continuous_linear(
+      ret = color_sequence_interpolate_color_continuous_linear(
           color_sequence, phase, &color);
       TEST_ASSERT_EQUAL_INT(0, ret);
 
@@ -205,7 +205,7 @@ void test_linear_case3(void) {
       double phase = ((idu - 1) / (double)(width - 3));
 
       // perform the interpolation
-      ret = color_sequence_get_color_discrete_linear(
+      ret = color_sequence_interpolate_color_discrete_linear(
           color_sequence, phase, &color);
       TEST_ASSERT_EQUAL_INT(0, ret);
 

--- a/test/tests/fields/src/specific.c
+++ b/test/tests/fields/src/specific.c
@@ -43,15 +43,15 @@ static void test_specific_field(
     sequence_map_fn map_fn = NULL;
     if (discrete) {
       if (circular) {
-        map_fn = color_sequence_get_color_discrete_circular;
+        map_fn = color_sequence_interpolate_color_discrete_circular;
       } else {
-        map_fn = color_sequence_get_color_discrete_linear;
+        map_fn = color_sequence_interpolate_color_discrete_linear;
       }
     } else {
       if (circular) {
-        map_fn = color_sequence_get_color_continuous_circular;
+        map_fn = color_sequence_interpolate_color_continuous_circular;
       } else {
-        map_fn = color_sequence_get_color_continuous_linear;
+        map_fn = color_sequence_interpolate_color_continuous_linear;
       }
     }
 


### PR DESCRIPTION
this is a breaking change in the API, and so usually should be accompanied by a major version increase, but because sicgl is still in pre-release (v0.x.x) we will disregard this in this case...